### PR TITLE
README is misleading, need ninja, not make

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ The implemented architecture is based on the original Vision Transformer from:
 
     # build ggml and vit 
     mkdir build && cd build
-    cmake .. && make -j4
+    cmake .. && ninja
 
     # run inference
     ./bin/vit -t 4 -m ../ggml-model-f16.gguf -i ../assets/tench.jpg


### PR DESCRIPTION
I have little experience with c++ projects, tried to follow the README, failed, and found that you need `ninja` instead of `make` in `build` dir. This PR will save other newbies some time.