### PR TITLE
FIX: ggml_time_init() before ggml_time_us()

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -25,6 +25,7 @@
 // main function
 int main(int argc, char **argv)
 {
+    ggml_time_init();
     const int64_t t_main_start_us = ggml_time_us();
 
     vit_params params;


### PR DESCRIPTION
main.cpp fix

Initialize GGML timer before first use to prevent divide‑by‑zero crash on Windows

ggml_time_us() divides by timer_freq, which is set in ggml_time_init().
When main() called ggml_time_us() before that initialization, timer_freq == 0, causing a STATUS_INTEGER_DIVIDE_BY_ZERO (0xC0000094) crash on Windows/MinGW.

at the very top of main().
The first line safely sets timer_freq; the second keeps behaviour identical by recording the start timestamp.

Result

ViT CLI no longer crashes with exit code –1073741676.

--help, inference, and verbose timing output all work as expected on Windows/MinGW, Linux, and macOS.

No other code paths are affected.